### PR TITLE
An initial tweak of the grouping exercise requirements, based on team feedback

### DIFF
--- a/grouping/README.md
+++ b/grouping/README.md
@@ -11,8 +11,10 @@ The resulting program should allow us to test at least three matching types:
 ## Guidelines
 
 * **Please DO NOT fork this repository with your solution**
-* Use any language you want, as long as it can be compiled on OSX
+* You should use Ruby to complete this assignment.
 * Only use code that you have license to use
+* Your submission should be complete, including the kinds of tests, documentation and other artifacts you'd normally provide as part of a pull request or finished solution.
+* Bear in mind that our interviewers will need to run your code to evaluate it, so consider dependencies carefully.
 * Don't hesitate to ask us any questions to clarify the project
 
 ## Resources


### PR DESCRIPTION
We can go a lot further here, possibly redesigning the exercise entirely, but for now I think this will take care of some common issues we're seeing, namely:

- Submissions made in a language other than Ruby are frequently harder to assess, even though the rubric says they're fine.
- Because the instructions are so sparse, there's wide variability in what people do and don't include, as far as documentation and tests goes. The new wording _strongly encourages_ them to consider those things, whilst still leaving them to decide what they "normally provide".

