### PR TITLE
INTERNAL: Encourage AI tool usage in grouping exercise

### DIFF
--- a/grouping/README.md
+++ b/grouping/README.md
@@ -12,10 +12,16 @@ The resulting program should allow us to test at least three matching types:
 
 * **Please DO NOT fork this repository with your solution**
 * You should use Ruby to complete this assignment.
-* Only use code that you have license to use
+* Only use code that you have license to use (AI-generated code is fine; standard open-source licenses apply to any third-party libraries)
 * Your submission should be complete, including the kinds of tests, documentation and other artifacts you'd normally provide as part of a pull request or finished solution.
 * Bear in mind that our interviewers will need to run your code to evaluate it, so consider dependencies carefully.
 * Don't hesitate to ask us any questions to clarify the project
+
+## Using AI Tools
+
+We encourage you to use AI assistants (Claude, ChatGPT, Copilot, etc.) as part of your workflow, just as you would on the job. The only requirement is that you understand and can explain everything you submit.
+
+In your README, include a short paragraph on your process -- specifically, how you used AI tools (if at all), what they helped with, and where you had to course-correct or override them. If you used AI, also include the prompts or instructions you gave it. This gives us insight into how you break down problems and direct AI tools, which is increasingly a core engineering skill.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

This PR makes our AI stance explicit.

- Clarifies the licensing guideline to explicitly permit AI-generated code
- Adds a **Using AI Tools** section encouraging candidates to use AI assistants as they would on the job
- Asks candidates to share their prompts/instructions alongside a short process reflection, giving interviewers a new signal on how candidates direct and work with AI tools

## Quality Assurances

- [x] README renders correctly on GitHub
- [x] Wording is unambiguous for candidates

<details>
<summary>AI Conversation Summary</summary>

**Intent:** Update the grouping exercise README to explicitly encourage AI tool usage and ask candidates to share their AI prompts as part of their submission.

**Key Decisions:**
- Added a dedicated "Using AI Tools" section rather than burying guidance in the existing guidelines list, to make it more prominent
- Clarified the existing licensing line to remove ambiguity about AI-generated code
- Asked for prompts specifically because how a candidate instructs AI is increasingly a core engineering skill worth evaluating

**Discovery:** Fetched the raw README from GitHub, found it was concise and guideline-focused -- kept the new section consistent with that tone.

</details>